### PR TITLE
Fix identification of source blocks

### DIFF
--- a/ast/src/attr_list.rs
+++ b/ast/src/attr_list.rs
@@ -91,10 +91,14 @@ impl<'arena> AttrList<'arena> {
     self.source_language().is_some()
   }
 
-  // TODO: this is incorrect, see https://github.com/jaredh159/asciidork/issues/4
   pub fn source_language(&self) -> Option<&str> {
-    match (self.str_positional_at(0), self.str_positional_at(1)) {
-      (None | Some("source"), Some(lang)) => Some(lang),
+    match (
+      self.str_positional_at(0),
+      self.str_positional_at(1),
+      self.id.is_some(),
+    ) {
+      (None | Some("source"), Some(lang), false) => Some(lang),
+      (Some(lang), None, true) => Some(lang),
       _ => None,
     }
   }

--- a/dr-html-backend/src/asciidoctor_html.rs
+++ b/dr-html-backend/src/asciidoctor_html.rs
@@ -1019,10 +1019,17 @@ impl AsciidoctorHtml {
       .meta
       .attrs
       .as_ref()
-      .map(|a| (a.str_positional_at(0), a.str_positional_at(1)))
-      .unwrap_or((None, None))
+      .map(|a| {
+        (
+          a.str_positional_at(0),
+          a.str_positional_at(1),
+          a.id.is_some(),
+        )
+      })
+      .unwrap_or((None, None, false))
     {
-      (None | Some("source"), Some(lang)) => Some(Cow::Borrowed(lang)),
+      (None | Some("source"), Some(lang), false) => Some(Cow::Borrowed(lang)),
+      (Some(lang), None, true) => Some(Cow::Borrowed(lang)),
       _ => self
         .doc_meta
         .str("source-language")

--- a/dr-html-backend/tests/all/eval_source.rs
+++ b/dr-html-backend/tests/all/eval_source.rs
@@ -31,6 +31,7 @@ assert_html!(
     ----
   "#},
   wrap_source(
+    None,
     "ruby",
     raw_html! {r#"
       require 'sinatra'
@@ -52,6 +53,7 @@ assert_html!(
     end
   "#},
   wrap_source(
+    None,
     "ruby",
     raw_html! {r#"
       require 'sinatra'
@@ -71,7 +73,7 @@ assert_html!(
     require 'sinatra'
     ----
   "#},
-  wrap_source("ruby", "require 'sinatra'")
+  wrap_source(None, "ruby", "require 'sinatra'")
 );
 
 assert_html!(
@@ -84,7 +86,7 @@ assert_html!(
     System.out.println("Hello, world!");
     ----
   "#},
-  wrap_source("java", r#"System.out.println("Hello, world!");"#)
+  wrap_source(None, "java", r#"System.out.println("Hello, world!");"#)
 );
 
 assert_html!(
@@ -98,6 +100,7 @@ assert_html!(
     ----
   "#},
   wrap_source(
+    None,
     "rust",
     raw_html! {r#"
       fn main() {
@@ -115,10 +118,13 @@ assert_html!(
     so baz
     ----
   "#},
-  wrap_listing(raw_html! {r#"
+  wrap_listing(
+    None,
+    raw_html! {r#"
     <pre>foo &lt;bar&gt;
     so baz</pre>
-  "#})
+  "#}
+  )
 );
 
 assert_html!(
@@ -130,17 +136,51 @@ assert_html!(
     so baz
     --
   "#},
-  wrap_listing(raw_html! {r#"
+  wrap_listing(
+    None,
+    raw_html! {r#"
     <pre>foo bar
     so baz</pre>
-  "#})
+  "#}
+  )
+);
+
+assert_html!(
+  source_block_id,
+  adoc! {r#"
+    [#hello,ruby]
+    ----
+    require 'sinatra'
+
+    get '/hi' do
+      "Hello World!"
+    end
+    ----
+  "#},
+  wrap_source(
+    Some("hello"),
+    "ruby",
+    raw_html! {r#"
+      require 'sinatra'
+
+      get '/hi' do
+        "Hello World!"
+      end
+    "#}
+  )
 );
 
 // helpers
 
-fn wrap_listing(inner: &str) -> String {
+fn wrap_listing(id: Option<&str>, inner: &str) -> String {
+  let div = if let Some(id) = id {
+    &format!(r#"<div id="{}" class="listingblock">"#, id)
+  } else {
+    r#"<div class="listingblock">"#
+  };
   format!(
-    r#"<div class="listingblock"><div class="content">{}</div></div>"#,
+    r#"{}<div class="content">{}</div></div>"#,
+    div,
     inner.trim(),
   )
 }
@@ -152,9 +192,12 @@ fn wrap_literal(inner: &str) -> String {
   )
 }
 
-fn wrap_source(lang: &str, inner: &str) -> String {
-  wrap_listing(&format!(
-    r#"<pre class="highlight"><code class="language-{lang}" data-lang="{lang}">{}</code></pre>"#,
-    inner.trim(),
-  ))
+fn wrap_source(id: Option<&str>, lang: &str, inner: &str) -> String {
+  wrap_listing(
+    id,
+    &format!(
+      r#"<pre class="highlight"><code class="language-{lang}" data-lang="{lang}">{}</code></pre>"#,
+      inner.trim(),
+    ),
+  )
 }


### PR DESCRIPTION
Handle that the first attribute for a source block can be an ID.

Fixes #4