### PR TITLE
Fix clippy warnings

### DIFF
--- a/ast/src/attr_list.rs
+++ b/ast/src/attr_list.rs
@@ -146,7 +146,7 @@ impl<'arena> Named<'arena> {
     Named(BumpVec::new_in(bump))
   }
 
-  pub fn from(vec: BumpVec<'arena, (SourceString<'arena>, InlineNodes<'arena>)>) -> Self {
+  pub const fn from(vec: BumpVec<'arena, (SourceString<'arena>, InlineNodes<'arena>)>) -> Self {
     Named(vec)
   }
 

--- a/ast/src/block.rs
+++ b/ast/src/block.rs
@@ -7,7 +7,7 @@ pub struct Block<'arena> {
   pub context: BlockContext,
 }
 
-impl<'arena> Block<'arena> {
+impl Block<'_> {
   pub fn has_attr_option(&self, name: &str) -> bool {
     self
       .meta
@@ -93,7 +93,7 @@ pub enum BlockContext {
   Video,
 }
 
-impl<'arena> BlockContent<'arena> {
+impl BlockContent<'_> {
   pub fn last_loc(&self) -> Option<SourceLocation> {
     match self {
       BlockContent::Compound(blocks) => blocks.last().and_then(|b| b.content.last_loc()),

--- a/ast/src/col_widths.rs
+++ b/ast/src/col_widths.rs
@@ -31,7 +31,7 @@ pub enum DistributedColWidth {
 }
 
 impl<'arena> ColWidths<'arena> {
-  pub fn new(col_widths: BumpVec<'arena, ColWidth>) -> Self {
+  pub const fn new(col_widths: BumpVec<'arena, ColWidth>) -> Self {
     Self(col_widths)
   }
 

--- a/ast/src/inline.rs
+++ b/ast/src/inline.rs
@@ -63,7 +63,7 @@ pub enum SpecialCharKind {
 
 // json
 
-impl<'arena> Json for InlineNode<'arena> {
+impl Json for InlineNode<'_> {
   fn to_json_in(&self, buf: &mut JsonBuf) {
     buf.begin_obj("InlineNode");
     buf.add_member("content", &self.content);
@@ -89,7 +89,7 @@ impl Json for CurlyKind {
   }
 }
 
-impl<'arena> Json for Inline<'arena> {
+impl Json for Inline<'_> {
   fn to_json_in(&self, buf: &mut JsonBuf) {
     buf.begin_obj("Inline");
     buf.push_str(r#","variant":""#);

--- a/ast/src/inline_nodes.rs
+++ b/ast/src/inline_nodes.rs
@@ -93,7 +93,7 @@ impl<'arena> Deref for InlineNodes<'arena> {
   }
 }
 
-impl<'arena> DerefMut for InlineNodes<'arena> {
+impl DerefMut for InlineNodes<'_> {
   fn deref_mut(&mut self) -> &mut Self::Target {
     &mut self.0
   }

--- a/ast/src/json.rs
+++ b/ast/src/json.rs
@@ -97,7 +97,7 @@ impl Json for &str {
   }
 }
 
-impl<'arena> Json for BumpString<'arena> {
+impl Json for BumpString<'_> {
   fn to_json_in(&self, buf: &mut JsonBuf) {
     self.as_str().to_json_in(buf);
   }

--- a/ast/src/list.rs
+++ b/ast/src/list.rs
@@ -18,7 +18,7 @@ pub enum ListItemTypeMeta<'arena> {
   None,
 }
 
-impl<'arena> ListItem<'arena> {
+impl ListItem<'_> {
   pub const fn loc_start(&self) -> u32 {
     self.marker_src.loc.start
   }

--- a/ast/src/source_string.rs
+++ b/ast/src/source_string.rs
@@ -49,7 +49,7 @@ impl Json for SourceString<'_> {
   }
 }
 
-impl<'arena> Deref for SourceString<'arena> {
+impl Deref for SourceString<'_> {
   type Target = str;
 
   fn deref(&self) -> &Self::Target {
@@ -57,19 +57,19 @@ impl<'arena> Deref for SourceString<'arena> {
   }
 }
 
-impl<'arena> AsRef<str> for SourceString<'arena> {
+impl AsRef<str> for SourceString<'_> {
   fn as_ref(&self) -> &str {
     &self.src
   }
 }
 
-impl<'arena> std::cmp::PartialEq<str> for SourceString<'arena> {
+impl std::cmp::PartialEq<str> for SourceString<'_> {
   fn eq(&self, other: &str) -> bool {
     self.src == other
   }
 }
 
-impl<'arena> std::fmt::Debug for SourceString<'arena> {
+impl std::fmt::Debug for SourceString<'_> {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     write!(f, "SourceString{{\"{}\",{:?}}}", self.src, self.loc)
   }

--- a/ast/src/table.rs
+++ b/ast/src/table.rs
@@ -118,7 +118,7 @@ pub struct Row<'arena> {
 }
 
 impl<'arena> Row<'arena> {
-  pub fn new(cells: BumpVec<'arena, Cell<'arena>>) -> Self {
+  pub const fn new(cells: BumpVec<'arena, Cell<'arena>>) -> Self {
     Self { cells }
   }
 }

--- a/dr-html-backend/src/asciidoctor_html.rs
+++ b/dr-html-backend/src/asciidoctor_html.rs
@@ -1087,7 +1087,7 @@ impl AsciidoctorHtml {
       Some(AttrValue::String(path)) => {
         let ext = helpers::file_ext(path).unwrap_or("ico");
         self.push_str(r#"<link rel="icon" type="image/"#);
-        self.push([ext, r#"" href=""#, &path, "\">"]);
+        self.push([ext, r#"" href=""#, path, "\">"]);
       }
       Some(AttrValue::Bool(true)) => {
         self.push_str(r#"<link rel="icon" type="image/x-icon" href="favicon.ico">"#);

--- a/dr-html-backend/src/htmlbuf.rs
+++ b/dr-html-backend/src/htmlbuf.rs
@@ -16,6 +16,7 @@ pub trait HtmlBuf {
     }
   }
 
+  #[allow(unused)]
   fn push_url_encoded(&mut self, s: &str) {
     push_url_encoded(self.htmlbuf(), s);
   }

--- a/parser/src/contiguous_lines.rs
+++ b/parser/src/contiguous_lines.rs
@@ -46,7 +46,7 @@ impl<'arena> ContiguousLines<'arena> {
     self.current()
   }
 
-  pub fn iter(&'arena self) -> impl ExactSizeIterator<Item = &Line<'arena>> + '_ {
+  pub fn iter(&'arena self) -> impl ExactSizeIterator<Item = &'arena Line<'arena>> + 'arena {
     self.lines.iter()
   }
 

--- a/parser/src/delimiter.rs
+++ b/parser/src/delimiter.rs
@@ -27,7 +27,7 @@ impl From<Delimiter> for BlockContext {
   }
 }
 
-impl<'arena> Token<'arena> {
+impl Token<'_> {
   pub fn to_delimeter(&self) -> Option<Delimiter> {
     if self.kind != TokenKind::DelimiterLine {
       return None;

--- a/parser/src/deq.rs
+++ b/parser/src/deq.rs
@@ -30,7 +30,7 @@ impl<'arena, T> Deq<'arena, T> {
     }
   }
 
-  pub fn from_vec(bump: &'arena Bump, buf: BumpVec<'arena, T>) -> Self {
+  pub const fn from_vec(bump: &'arena Bump, buf: BumpVec<'arena, T>) -> Self {
     Deq { bump, buf, pos: 0 }
   }
 
@@ -151,7 +151,7 @@ impl<'arena, T: DefaultIn<'arena>> Deq<'arena, T> {
   }
 }
 
-impl<'arena, T: fmt::Debug> fmt::Debug for Deq<'arena, T> {
+impl<T: fmt::Debug> fmt::Debug for Deq<'_, T> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     write!(
       f,

--- a/parser/src/diagnostic.rs
+++ b/parser/src/diagnostic.rs
@@ -10,7 +10,7 @@ pub struct Diagnostic {
   pub source_file: SourceFile,
 }
 
-impl<'arena> Parser<'arena> {
+impl Parser<'_> {
   pub(crate) fn err_at(&self, message: impl Into<String>, start: u32, end: u32) -> Result<()> {
     let (line_num, offset) = self.lexer.line_number_with_offset(start);
     self.handle_err(Diagnostic {

--- a/parser/src/lexer/source_lexer.rs
+++ b/parser/src/lexer/source_lexer.rs
@@ -14,7 +14,7 @@ pub struct SourceLexer<'arena> {
 }
 
 impl<'arena> SourceLexer<'arena> {
-  pub fn new(
+  pub const fn new(
     src: BumpVec<'arena, u8>,
     file: SourceFile,
     leveloffset: i8,
@@ -216,7 +216,7 @@ impl<'arena> SourceLexer<'arena> {
 
   fn whitespace(&mut self) -> Token<'arena> {
     let start = self.pos - 1;
-    self.advance_while_one_of(&[b' ', b'\t']);
+    self.advance_while_one_of(b" \t");
     self.token(Whitespace, start, self.pos)
   }
 
@@ -578,7 +578,7 @@ impl<'arena> SourceLexer<'arena> {
   }
 }
 
-impl<'arena> Debug for SourceLexer<'arena> {
+impl Debug for SourceLexer<'_> {
   fn fmt(&self, f: &mut Formatter<'_>) -> Result {
     f.debug_struct("SourceLexer")
       .field("src", &String::from_utf8_lossy(&self.src))

--- a/parser/src/line.rs
+++ b/parser/src/line.rs
@@ -533,9 +533,7 @@ impl<'arena> Line<'arena> {
     if self.current_token().is(Whitespace) {
       offset += 1;
     }
-    let Some(token) = self.nth_token(offset) else {
-      return None;
-    };
+    let token = self.nth_token(offset)?;
     let second = self.nth_token(offset + 1);
     let third = self.nth_token(offset + 2);
 
@@ -547,9 +545,7 @@ impl<'arena> Line<'arena> {
       }
       Star if second.is(Star) => {
         let src = self.reassemble_src();
-        let Some(captures) = regx::REPEAT_STAR_LI_START.captures(&src) else {
-          return None;
-        };
+        let captures = regx::REPEAT_STAR_LI_START.captures(&src)?;
         Some(ListMarker::Star(captures.get(1).unwrap().len() as u8))
       }
       CalloutNumber if token.lexeme.as_bytes()[1] != b'!' => {

--- a/parser/src/tasks/collect_text.rs
+++ b/parser/src/tasks/collect_text.rs
@@ -101,7 +101,7 @@ impl<'arena> CollectText<'arena> {
   }
 }
 
-impl<'arena> std::fmt::Debug for CollectText<'arena> {
+impl std::fmt::Debug for CollectText<'_> {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     write!(
       f,

--- a/parser/src/tasks/directives/ifdef.rs
+++ b/parser/src/tasks/directives/ifdef.rs
@@ -34,7 +34,7 @@ impl<'arena> Parser<'arena> {
   fn evaluate_ifdef(&self, defined: bool, attrs: &str) -> bool {
     let is_any = attrs.contains(',');
     let mut result = attrs
-      .split(|c| c == ',' || c == '+')
+      .split([',', '+'])
       .fold(!is_any, |current, attr| {
         if !is_any && !current && defined {
           false

--- a/parser/src/tasks/directives/includes/include_resolver.rs
+++ b/parser/src/tasks/directives/includes/include_resolver.rs
@@ -63,7 +63,7 @@ impl IncludeBuffer for Vec<u8> {
   }
 }
 
-impl<'a> IncludeBuffer for BumpVec<'a, u8> {
+impl IncludeBuffer for BumpVec<'_, u8> {
   fn initialize(&mut self, len: usize) {
     self.reserve(len + 1); // for possible extra newline
     self.resize(len, 0);
@@ -108,8 +108,9 @@ impl From<std::io::Error> for ResolveError {
 
 // test helpers
 
-#[cfg(not(release))]
+#[cfg(debug_assertions)]
 pub struct ConstResolver(pub Vec<u8>);
+#[cfg(debug_assertions)]
 impl IncludeResolver for ConstResolver {
   fn resolve(
     &mut self,
@@ -127,8 +128,9 @@ impl IncludeResolver for ConstResolver {
   }
 }
 
-#[cfg(not(release))]
+#[cfg(debug_assertions)]
 pub struct ErrorResolver(pub ResolveError);
+#[cfg(debug_assertions)]
 impl IncludeResolver for ErrorResolver {
   fn resolve(
     &mut self,

--- a/parser/src/tasks/directives/includes/normalize_includes.rs
+++ b/parser/src/tasks/directives/includes/normalize_includes.rs
@@ -156,7 +156,7 @@ fn from_utf16_in(utf16: BumpVec<u16>, dest: &mut BumpVec<u8>, bump: &Bump) -> bo
 
 fn parse_line_ranges(s: &str) -> Vec<Range<usize>> {
   let mut ranges = Vec::new();
-  s.split(|c| c == ',' || c == ';').for_each(|part| {
+  s.split([',', ';']).for_each(|part| {
     let part = part.trim();
     if let Some((low, high)) = part.split_once("..") {
       let Ok(low_n) = low.parse::<usize>() else {

--- a/parser/src/tasks/directives/includes/tags.rs
+++ b/parser/src/tasks/directives/includes/tags.rs
@@ -151,7 +151,7 @@ pub fn parse_spec(s: &str) -> Option<Spec> {
 pub fn parse_selection(s: &str) -> TagSpecs {
   let mut selection = TagSpecs(Vec::new());
   s.trim()
-    .split(|c| c == ',' || c == ';')
+    .split([',', ';'])
     .filter_map(parse_spec)
     .for_each(|spec| {
       selection.push(spec);

--- a/parser/src/tasks/heading_level.rs
+++ b/parser/src/tasks/heading_level.rs
@@ -2,9 +2,7 @@ use crate::internal::*;
 
 impl<'arena> Parser<'arena> {
   pub fn line_heading_level(&self, line: &Line) -> Option<u8> {
-    let Some(unadjusted) = line.unadjusted_heading_level() else {
-      return None;
-    };
+    let unadjusted = line.unadjusted_heading_level()?;
     Some(adjusted_leveloffset(
       self.lexer.leveloffset(line.loc().unwrap().include_depth),
       adjusted_leveloffset(self.ctx.leveloffset, unadjusted),

--- a/parser/src/tasks/parse_attr_list.rs
+++ b/parser/src/tasks/parse_attr_list.rs
@@ -1594,7 +1594,7 @@ mod tests {
     }
   }
 
-  impl<'a> AttrIr<'a> {
+  impl AttrIr<'_> {
     fn assert_string(&self) -> String {
       match self {
         AttrIr::Id(tokens) => format!("Id({})", toks_to_string(tokens)),

--- a/parser/src/tasks/parse_block.rs
+++ b/parser/src/tasks/parse_block.rs
@@ -312,11 +312,11 @@ impl<'arena> Parser<'arena> {
         lines.current().unwrap().last_loc().unwrap().end,
       )?;
     }
-    return Ok(Block {
+    Ok(Block {
       meta,
       context: Context::TableOfContents,
       content: Content::Empty(EmptyMetadata::None),
-    });
+    })
   }
 }
 

--- a/parser/src/tasks/parse_inlines/mod.rs
+++ b/parser/src/tasks/parse_inlines/mod.rs
@@ -763,7 +763,7 @@ impl<'arena> Parser<'arena> {
     let mut line_txt = state.text.str().as_bytes();
     let line_len = line_txt.len();
     let mut back = comment_bytes.len() as u32;
-    if line_txt.ends_with(&[b' ']) {
+    if line_txt.ends_with(b" ") {
       back += 1;
       line_txt = &line_txt[..line_len - 1];
     }

--- a/parser/src/tasks/parse_revision_line.rs
+++ b/parser/src/tasks/parse_revision_line.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use crate::internal::*;
 use crate::variants::token::*;
 
-impl<'arena> Parser<'arena> {
+impl Parser<'_> {
   pub(super) fn parse_revision_line(&mut self, lines: &mut ContiguousLines) {
     let Some(line) = lines.current() else {
       return;

--- a/parser/src/tasks/table/context.rs
+++ b/parser/src/tasks/table/context.rs
@@ -55,7 +55,7 @@ pub enum DsvLastConsumed {
   Other,
 }
 
-impl<'arena> TableContext<'arena> {
+impl TableContext<'_> {
   pub fn add_phantom_cells(&mut self, cell: &Cell, col: usize) {
     if cell.row_span == 0 && cell.col_span == 0 {
       return;

--- a/parser/src/tasks/table/parse_table_spec.rs
+++ b/parser/src/tasks/table/parse_table_spec.rs
@@ -93,12 +93,8 @@ impl<'arena> Parser<'arena> {
   }
 
   fn peek_cell_start(&self, tokens: &mut TableTokens, sep: char) -> Option<CellStart> {
-    let Some(first_token) = tokens.current_mut() else {
-      return None;
-    };
-    let Some(first_byte) = first_token.lexeme.as_bytes().first() else {
-      return None;
-    };
+    let first_token = tokens.current_mut()?;
+    let first_byte = first_token.lexeme.as_bytes().first()?;
 
     // no explicit cell spec, but we're sitting on the sep, so infer default
     if first_token.lexeme.starts_with(sep) {
@@ -140,9 +136,7 @@ impl<'arena> Parser<'arena> {
     if cursor == 0 {
       return None;
     }
-    let Some(cursor_token) = tokens.nth(cursor as usize) else {
-      return None;
-    };
+    let cursor_token = tokens.nth(cursor as usize)?;
 
     let mut buf = [0; 4];
     let sep_bytes = sep.encode_utf8(&mut buf).as_bytes();

--- a/parser/src/token.rs
+++ b/parser/src/token.rs
@@ -181,7 +181,7 @@ impl<'arena> DefaultIn<'arena> for Token<'arena> {
   }
 }
 
-impl<'arena> TokenIs for Token<'arena> {
+impl TokenIs for Token<'_> {
   fn is(&self, kind: TokenKind) -> bool {
     self.kind == kind
   }
@@ -203,7 +203,7 @@ impl<'arena> TokenIs for Token<'arena> {
   }
 }
 
-impl<'arena> TokenIs for Option<&Token<'arena>> {
+impl TokenIs for Option<&Token<'_>> {
   fn is(&self, kind: TokenKind) -> bool {
     self.map_or(false, |t| t.is(kind))
   }
@@ -221,7 +221,7 @@ impl<'arena> TokenIs for Option<&Token<'arena>> {
   }
 }
 
-impl<'arena> std::fmt::Debug for Token<'arena> {
+impl std::fmt::Debug for Token<'_> {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     let lexeme = if &self.lexeme == "\n" {
       "\\n".to_string()


### PR DESCRIPTION
This PR fixed multiple kinds of `clippy` warnings in this project:
- Functions that can be `const`.
- Inappropriate or redundant lifetime names.
- Use `b" \t"` instead of `&[b' ', b'\t']`.
- Detect profile with `cfg(debug_assertions)`.
- Use `?` instead of `let Some(...) = ... else { return None; }`.