### PR TITLE
Add calculate_file_location(SourceLocation) to Parser

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -315,6 +315,29 @@ impl<'arena> Parser<'arena> {
   pub(crate) fn string(&self, s: &str) -> BumpString<'arena> {
     BumpString::from_str_in(s, self.bump)
   }
+
+  pub fn calculate_file_location(&self, loc: SourceLocation) -> SourceFileLocation {
+    let (line_num, col) = self.lexer.line_number_with_offset(loc);
+    SourceFileLocation {
+      line_num,
+      col,
+      source_file: self.lexer.source_file_at(loc.include_depth).clone(),
+    }
+  }
+
+  pub fn calculate_file_locations(&self, locs: &[SourceLocation]) -> Vec<SourceFileLocation> {
+    // TODO: make optimised version of this that does only one scan per source_file
+    locs
+      .iter()
+      .map(|loc| self.calculate_file_location(*loc))
+      .collect()
+  }
+}
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct SourceFileLocation {
+  pub line_num: u32,
+  pub col: u32,
+  pub source_file: SourceFile,
 }
 
 pub trait HasArena<'arena> {


### PR DESCRIPTION
This PR adds two methods to Parser:

```rust
pub fn calculate_file_location(&self, loc: SourceLocation) -> SourceFileLocation

pub fn calculate_file_locations(&self, locs: &[SourceLocation]) -> Vec<SourceFileLocation>
```
And a struct

```rust
#[derive(Debug, Eq, PartialEq, Clone)]
pub struct SourceFileLocation {
  pub line_num: u32,
  pub col: u32,
  pub source_file: SourceFile,
}
```

I want to be able to provide the line and column locations of various things my `Backend` and `AttrRefObserver` finds. So after a parse, I have a bunch of `SourceLocation`s that I want to process. I can do these one at a time using `calculate_file_location`, but each one involves a full scan of a source file, and I'll have a lot of these. So, I also provide `calculate_file_locations` to look up `SourceLocation`s in bulk.

In this PR, `calculate_file_locations` just calls `calculate_file_location` for each, so there's no actual advantage. But I want to create a version that does a single scan through each relevant source file.

Two questions:
1. Does this look like an addition that fits with the design of Asciidork?
2. Can you offer some pointers on how to write tests for this?

Thanks for reading!