### PR TITLE
add source file location lookups to ParseResult

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::{cell::RefCell, rc::Rc};
 
@@ -268,7 +269,7 @@ impl<'arena> Parser<'arena> {
       warnings: self.errors.into_inner(),
       #[cfg(feature = "attr_ref_observation")]
       attr_ref_observer: self.attr_ref_observer,
-      lexer: self.lexer
+      lexer: self.lexer,
     })
   }
 
@@ -424,11 +425,18 @@ impl Debug for ParseResult<'_> {
 }
 
 impl<'arena> ParseResult<'arena> {
-  pub fn line_number_with_offset(&self,  loc: SourceLocation) -> (u32, u32) {
+  pub fn line_number_with_offset(&self, loc: SourceLocation) -> (u32, u32) {
     self.lexer.line_number_with_offset(loc)
   }
+
   pub fn source_file_at(&self, idx: u16) -> &SourceFile {
     self.lexer.source_file_at(idx)
+  }
+
+  pub fn take_attr_ref_observer<T: 'static>(&mut self) -> Option<T> {
+    let observer = self.attr_ref_observer.take()?;
+    let observer = observer as Box<dyn Any>;
+    Some(*observer.downcast::<T>().unwrap())
   }
 }
 

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -22,6 +22,7 @@ pub struct ParseResult<'arena> {
   pub warnings: Vec<Diagnostic>,
   #[cfg(feature = "attr_ref_observation")]
   pub attr_ref_observer: Option<Box<dyn AttrRefObserver>>,
+  pub(super) lexer: Lexer<'arena>,
 }
 
 impl<'arena> Parser<'arena> {
@@ -267,6 +268,7 @@ impl<'arena> Parser<'arena> {
       warnings: self.errors.into_inner(),
       #[cfg(feature = "attr_ref_observation")]
       attr_ref_observer: self.attr_ref_observer,
+      lexer: self.lexer
     })
   }
 
@@ -418,6 +420,15 @@ impl Debug for ParseResult<'_> {
       .field("document", &self.document)
       .field("warnings", &self.warnings)
       .finish()
+  }
+}
+
+impl<'arena> ParseResult<'arena> {
+  pub fn line_number_with_offset(&self,  loc: SourceLocation) -> (u32, u32) {
+    self.lexer.line_number_with_offset(loc)
+  }
+  pub fn source_file_at(&self, idx: u16) -> &SourceFile {
+    self.lexer.source_file_at(idx)
   }
 }
 

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,4 +1,4 @@
-  #[cfg(feature = "attr_ref_observation")]
+#[cfg(feature = "attr_ref_observation")]
 use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::{cell::RefCell, rc::Rc};

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -339,14 +339,6 @@ impl<'arena> Parser<'arena> {
   pub(crate) fn string(&self, s: &str) -> BumpString<'arena> {
     BumpString::from_str_in(s, self.bump)
   }
-
-  pub fn line_number_with_offset(&self, loc: SourceLocation) -> (u32, u32) {
-    self.lexer.line_number_with_offset(loc)
-  }
-
-  pub fn source_file_at(&self, idx: u16) -> &SourceFile {
-    self.lexer.source_file_at(idx)
-  }
 }
 
 pub trait HasArena<'arena> {
@@ -425,7 +417,7 @@ impl Debug for ParseResult<'_> {
   }
 }
 
-impl<'arena> ParseResult<'arena> {
+impl ParseResult<'_> {
   pub fn line_number_with_offset(&self, loc: SourceLocation) -> (u32, u32) {
     self.lexer.line_number_with_offset(loc)
   }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,3 +1,4 @@
+  #[cfg(feature = "attr_ref_observation")]
 use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::{cell::RefCell, rc::Rc};
@@ -23,7 +24,7 @@ pub struct ParseResult<'arena> {
   pub warnings: Vec<Diagnostic>,
   #[cfg(feature = "attr_ref_observation")]
   pub attr_ref_observer: Option<Box<dyn AttrRefObserver>>,
-  pub(super) lexer: Lexer<'arena>,
+  lexer: Lexer<'arena>,
 }
 
 impl<'arena> Parser<'arena> {
@@ -433,6 +434,7 @@ impl<'arena> ParseResult<'arena> {
     self.lexer.source_file_at(idx)
   }
 
+  #[cfg(feature = "attr_ref_observation")]
   pub fn take_attr_ref_observer<T: 'static>(&mut self) -> Option<T> {
     let observer = self.attr_ref_observer.take()?;
     let observer = observer as Box<dyn Any>;

--- a/parser/src/tasks/table/parse_table.rs
+++ b/parser/src/tasks/table/parse_table.rs
@@ -222,7 +222,7 @@ impl<'arena> Parser<'arena> {
           mut warnings,
           #[cfg(feature = "attr_ref_observation")]
           attr_ref_observer,
-          lexer: _
+          ..
         }) => {
           if !warnings.is_empty() {
             self.lexer.reline_diagnostics(loc.start, &mut warnings);

--- a/parser/src/tasks/table/parse_table.rs
+++ b/parser/src/tasks/table/parse_table.rs
@@ -222,6 +222,7 @@ impl<'arena> Parser<'arena> {
           mut warnings,
           #[cfg(feature = "attr_ref_observation")]
           attr_ref_observer,
+          lexer: _
         }) => {
           if !warnings.is_empty() {
             self.lexer.reline_diagnostics(loc.start, &mut warnings);


### PR DESCRIPTION
Adds `line_number_with_offset` and `source_file_at` methods to `ParseResult` to convert source locations into lines / columns / source files.

Adds a helper method `take_attr_ref_observer` to `ParseResult` when feature `attr_ref_observation` is enabled. This enables taking an attr ref observer back from ownership that was previously given to the Parser.