### PR TITLE
Add no-header-footer as an alias of embedded cli option, to match asciidoctor

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -34,7 +34,7 @@ pub struct Args {
   #[clap(short, long, help = "Output file path - omit to write to stdout")]
   pub output: Option<std::path::PathBuf>,
 
-  #[clap(short, long, default_value = "false")]
+  #[clap(short, long, alias = "no-header-footer", default_value = "false")]
   #[clap(help = "Supress enclosing document structure")]
   pub embedded: bool,
 


### PR DESCRIPTION
This adds `--no-header-footer` as an alias of `--embedded`, to match the asciidoctor cli.

The short versions don't match, though. AsciiDoctor is like this:

```
-S, --safe-mode SAFE_MODE        set safe mode level explicitly: [unsafe, safe, server, secure] (default: unsafe)
                                 disables potentially dangerous macros in source files, such as include::[]
-s, --no-header-footer           suppress enclosing document structure and output an embedded document (default: false)
```

whereas asciidork is like this:

```
-s, --safe-mode <SAFE_MODE>   Set safe mode explicitly [default: secure]
-e, --embedded                Supress enclosing document structure
```

I don't think the asciidoctor -s (for suppress, presumably) makes much sense anyway?