### PR TITLE
Add a FILE positional parameter, to match asciidoctor

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -54,6 +54,15 @@ pub struct Args {
   #[clap(short = 't', long, default_value = "false")]
   #[clap(help = "Print timing/perf info\n")]
   pub print_timings: bool,
+
+  #[clap(help = "The file path to parse - omit to read from stdin")]
+  pub file: Option<std::path::PathBuf>,
+}
+
+impl Args {
+  pub fn input(&self) -> Option<&std::path::PathBuf> {
+    self.file.as_ref().or(self.input.as_ref())
+  }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -34,7 +34,7 @@ fn run(
   mut stderr: impl Write,
 ) -> Result<(), Box<dyn Error>> {
   let (src, src_file, base_dir, input_mtime) = {
-    if let Some(pathbuf) = &args.input {
+    if let Some(pathbuf) = args.input() {
       let abspath = dunce::canonicalize(pathbuf)?;
       let mut file = fs::File::open(pathbuf.clone())?;
       let mut input_mtime = None;


### PR DESCRIPTION
Adds a FILE optional positional param, to match asciidoctor:

```
❯ ./target/release/asciidork --help
🤓 Asciidork CLI

Usage: asciidork [OPTIONS] [FILE]

Arguments:
  [FILE]  The file path to parse - omit to read from stdin

Options:
  -i, --input <INPUT>           The file path to parse - omit to read from stdin
...
```