### PR TITLE
fix list marker detection for items starting with bold

### DIFF
--- a/dr-html-backend/tests/all/eval_lists.rs
+++ b/dr-html-backend/tests/all/eval_lists.rs
@@ -44,6 +44,24 @@ assert_html!(
 );
 
 assert_html!(
+  list_item_starting_with_bold,
+  adoc! {r#"
+    * *foo* bar
+    * **baz** qux
+    * jim
+  "#},
+  html! {r#"
+    <div class="ulist">
+      <ul>
+        <li><p><strong>foo</strong> bar</p></li>
+        <li><p><strong>baz</strong> qux</p></li>
+        <li><p>jim</p></li>
+      </ul>
+    </div>
+  "#}
+);
+
+assert_html!(
   multiline_list_principle_w_indent,
   adoc! {r#"
     * foo _bar_

--- a/parser/src/line.rs
+++ b/parser/src/line.rs
@@ -765,7 +765,16 @@ impl<'arena> Line<'arena> {
     let third = self.nth_token(offset + 2);
 
     match token.kind {
-      Star if second.kind(Whitespace) && third.is_some_and(|t| t.kind != Star) => {
+      // exclude only the markdown thematic break `* * *`, so that list items
+      // whose text starts with bold/strong (e.g. `* *foo*`) are still recognized
+      Star
+        if second.kind(Whitespace)
+          && third.is_some()
+          && !(self.num_tokens() == offset + 5
+            && third.kind(Star)
+            && self.nth_token(offset + 3).kind(Whitespace)
+            && self.nth_token(offset + 4).kind(Star)) =>
+      {
         Some(ListMarker::Star(1))
       }
       Dots if second.kind(Whitespace) && third.is_some() => {
@@ -1110,6 +1119,10 @@ mod tests {
       ("*** ", None),
       ("- - -", None), // markdown break
       ("* * *", None), // markdown break
+      ("* *foo*", Some(Star(1))),
+      ("* *foo* bar", Some(Star(1))),
+      ("* **foo**", Some(Star(1))),
+      ("* * foo", Some(Star(1))),
       (" ", None),
       (". ", None),
       (".. ", None),


### PR DESCRIPTION
## Problem

A bullet list item whose text begins with bold/strong formatting is not recognized as a list item — it falls through and renders as a plain paragraph.

```adoc
* *foo* bar
* **baz** qux
* jim
```

Currently renders as a paragraph containing literal `*` characters instead of a `<ul>`. Asciidoctor renders this as a 3-item unordered list with `<strong>` inside the first two items.

## Cause

`Line::list_marker()` rejects a `*` marker whenever the token following the trailing whitespace is also a `Star`:

```rust
Star if second.kind(Whitespace) && third.is_some_and(|t| t.kind != Star) => {
```

The intent was to keep the markdown-style thematic break `* * *` from being treated as a list, but the `t.kind != Star` guard over-rejects: any list item whose first word is `*bold*` or `**strong**` also has a `Star` in third position.

## Fix

Narrow the exclusion to the exact `* * *` thematic-break pattern (mirroring the check in `parse_block.rs`), so `* *bold*`, `* **strong**`, and `* * literal` are all accepted as list items while `* * *` still parses as a thematic break.

Added a unit test in `line.rs` and an HTML rendering test in `eval_lists.rs`. The existing `markdown_thematic_break` test still passes.
